### PR TITLE
FLA-1870: Add cache control

### DIFF
--- a/.github/workflows/.build-publish-docker.yaml
+++ b/.github/workflows/.build-publish-docker.yaml
@@ -33,7 +33,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,prefix={{date 'YYYY.MM.DD-HH.mm'}}-,priority=9002
-            
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.3.0
         with:
@@ -41,6 +41,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
 
       - name: Set output
         run: echo "Docker image ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM nginx:1.31.3-alpine-slim
 
-COPY ./frontend/ /usr/share/nginx/html
+ARG BUILD_VERSION=development
+
+COPY ./frontend/ /usr/share/nginx/html/
+
+RUN sed -i "s/__BUILD_VERSION__/${BUILD_VERSION}/g" \
+    /usr/share/nginx/html/index.html
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM nginx:1.31.3-alpine-slim
 ARG BUILD_VERSION=development
 
 COPY ./frontend/ /usr/share/nginx/html/
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf 
 
 RUN sed -i "s/__BUILD_VERSION__/${BUILD_VERSION}/g" \
-    /usr/share/nginx/html/index.html
+    /usr/share/nginx/html/index.html \
+    && nginx -t
 
 EXPOSE 80

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,8 +18,8 @@
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@5.0.0/dist/themes/addons/core-dark.min.css" />
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
-  <link rel="stylesheet" href="/css/theme-custom.css" />
-  <link rel="stylesheet" href="/css/to-top-button.css" />
+  <link rel="stylesheet" href="/css/theme-custom.css?v=__BUILD_VERSION__" />
+  <link rel="stylesheet" href="/css/to-top-button.css?v=__BUILD_VERSION__" />
 </head>
 
 <body class="loading">
@@ -109,7 +109,7 @@
   <script src="//unpkg.com/prismjs/components/prism-python.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-graphql.min.js"></script>
 
-  <script src="/js/to-top.js"></script>
+  <script src="/js/to-top.js?v=__BUILD_VERSION__"></script>
 </body>
 
 </html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location ~* \.(html|md)$ {
+    add_header Cache-Control "no-cache";
+    try_files $uri $uri/ =404; 
+  }
+
+  location ~* \.(css|js)$ {
+    add_header Cache-Control "no-cache";
+    try_files $uri =404;
+  }
+
+  location ~* \.(png|jpg|jpeg|gif|svg|ico|webp|woff|woff2)$ {
+    expires 7d;
+    add_header Cache-Control "public";
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
## Summary

- Add the Git commit SHA as a Docker build argument.
- Inject the build version into local CSS and JavaScript URLs to provide cache-busting.
- Add an Nginx configuration with:
  - No caching for HTML, Markdown, CSS, and JavaScript files.
  - Seven-day caching for images and fonts.
  - SPA fallback routing to `index.html`.