### PR TITLE
FLA-1868: Documentation for federation with Keycloak

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,6 +40,44 @@
       securityLevel: "strict",
     });
 
+    function repairRemoteIncludeUrl(url) {
+      if (!url) {
+        return url;
+      }
+
+      const localOrigin = window.location.origin;
+
+      const malformedPrefixes = [
+        `${localOrigin}http://`,
+        `${localOrigin}https://`,
+        `${localOrigin}/http://`,
+        `${localOrigin}/https://`,
+      ];
+
+      for (const prefix of malformedPrefixes) {
+        if (url.startsWith(prefix)) {
+          const externalUrl = url.slice(
+            prefix.startsWith(`${localOrigin}/`)
+              ? localOrigin.length + 1
+              : localOrigin.length
+          );
+
+          return new URL(externalUrl).href;
+        }
+      }
+
+      return url;
+    }
+
+    function renderMermaidDiagrams(hook) {
+      hook.doneEach(function () {
+        mermaid.init(
+          undefined,
+          document.querySelectorAll(".mermaid")
+        );
+      });
+    }
+
     window.$docsify = {
       name: "FINT",
       logo: "/_media/fint-novari.svg",
@@ -60,6 +98,20 @@
 
       markdown: {
         renderer: {
+          image(token) {
+            return this.origin.image.call(this, {
+              ...token,
+              href: repairRemoteIncludeUrl(token.href),
+            });
+          },
+
+          link(token) {
+            return this.origin.link.call(this, {
+              ...token,
+              href: repairRemoteIncludeUrl(token.href),
+            });
+          },
+
           code({ text, lang }) {
             if (lang === "mermaid") {
               return `<div class="mermaid">${text}</div>`;
@@ -71,11 +123,7 @@
       },
 
       plugins: [
-        function (hook) {
-          hook.doneEach(function () {
-            mermaid.init(undefined, document.querySelectorAll(".mermaid"));
-          });
-        },
+        renderMermaidDiagrams,
       ],
 
       search: {
@@ -88,7 +136,7 @@
       plantuml: {
         skin: "default",
       },
-    }; 
+    };
   </script>
 
   <script src="//cdn.jsdelivr.net/npm/docsify@5.0.0"></script>

--- a/frontend/technical/federation/_sidebar.md
+++ b/frontend/technical/federation/_sidebar.md
@@ -9,9 +9,11 @@
   * [JSON](technical/json.md)
   * [Testklient](technical/testclient.md)
   * [FINT curl](technical/fintcurl.md)
-  * [Federering](technical/federation/index.md) 
-  * [FINT internt](technical/fint-inside.md)
-* [FINT illustrert](cartoon.md)
+  * [Federering](technical/federation/index.md)
+    * [Keycloak](technical/federation/federation_keycloak.md)
+    * [VIGO-IDP (utfases)](technical/federation/federation_vigo_idp.md)
+  * [FINT internt](technical/fint-inside.md)   
+* [FINT illustrert](cartoon.md) 
 * [Tjenester](service.md)
 
 - ****

--- a/frontend/technical/federation/federation_keycloak.md
+++ b/frontend/technical/federation/federation_keycloak.md
@@ -1,0 +1,1 @@
+[Keycloak](https://raw.githubusercontent.com/FINTLabs/flais-keycloak/main/docs/external/no/fint/federation/federation.md ':include')

--- a/frontend/technical/federation/federation_vigo_idp.md
+++ b/frontend/technical/federation/federation_vigo_idp.md
@@ -3,7 +3,7 @@
 ## Oppsett av Azure AD Federering - VIGO-IDP
 
 ### Virkemåte
-![ill1](../_media/vigo-idp/vigoidp1.png)
+![ill1](../../_media/vigo-idp/vigoidp1.png)
 
 - I vigoBAS hentes studentnumber og employeeId fra Fint.
 
@@ -21,7 +21,7 @@
 
 ### Legge til en "Enterprise app"
 
-Hver fylkeskommune må sette opp en Enterprise applications i sin egen Azure tenant. 
+Hver fylkeskommune må sette opp en Enterprise applications i sin egen Azure tenant.
 
 - Logg inn på egen Azure tenant https://portal.azure.com
 
@@ -33,20 +33,20 @@ Hver fylkeskommune må sette opp en Enterprise applications i sin egen Azure ten
 
 - Gi den ett navn (VIGO-IDP)
 
-![ill2](../_media/vigo-idp/vigoidp2.png)
+![ill2](../../_media/vigo-idp/vigoidp2.png)
 
 - Appen lages og når den popper opp - > klikk på “ 2. Set up single sign on”
 
-![ill3](../_media/vigo-idp/vigoidp3.png)
+![ill3](../../_media/vigo-idp/vigoidp3.png)
 
 - Klikk på [Create]
 - Klikk på "SAML"
 
-![ill4](../_media/vigo-idp/vigoidp4.png)
+![ill4](../../_media/vigo-idp/vigoidp4.png)
 
 - Klikk på “Edit” under punkt 1 “Basic SAML Configuration”
 
-![ill5](../_media/vigo-idp/vigoidp5.png)
+![ill5](../../_media/vigo-idp/vigoidp5.png)
 
 - Fyll inn “Identifier (Entity ID):
 
@@ -56,7 +56,7 @@ https://idp.felleskomponent.no/nidp/saml2/metadata
 
 https://idp.felleskomponent.no/nidp/saml2/spassertion_consumer@
 
-![ill6](../_media/vigo-idp/vigoidp6.png)
+![ill6](../../_media/vigo-idp/vigoidp6.png)
 
 - Klikk "Save"
 
@@ -64,19 +64,19 @@ https://idp.felleskomponent.no/nidp/saml2/spassertion_consumer@
 
 - Gå tilbake til Azure Active Directory og klikk på “App registrations”:
 
-![ill7](../_media/vigo-idp/vigoidp7.png)
+![ill7](../../_media/vigo-idp/vigoidp7.png)
 
 - Klikk på “All applications”. Da kommer alle apper i tennanten opp. Hvis du ikke ser “VIGO-IDP” så søk den opp. Klikk på “VIGO-IDP” appen.
 
-![ill8](../_media/vigo-idp/vigoidp8.png)
+![ill8](../../_media/vigo-idp/vigoidp8.png)
 
 - Klikk på “App roles|Preview”:
 
-![ill9](../_media/vigo-idp/vigoidp9.png)
+![ill9](../../_media/vigo-idp/vigoidp9.png)
 
 - Klikk på “ + Create app role”:
 
-![ill10](../_media/vigo-idp/vigoidp10.png)
+![ill10](../../_media/vigo-idp/vigoidp10.png)
 
 Fyll inn:
 
@@ -87,7 +87,7 @@ Fyll inn:
 
 Klikk på [Apply]
 
-![ill11](../_media/vigo-idp/create-app-role.png)
+![ill11](../../_media/vigo-idp/create-app-role.png)
 
 
 For å opprette flere roller: gjenta prosessen ved å trykke på “ +Create app role” og fyll inn som ovenfor. 
@@ -100,67 +100,67 @@ Figuren under viser 4 roller som er satt opp:
 
 Alle rollene, med beskrivelse, finnes i Rollekatalogen: https://role-catalog.vigoiks.no
 
-![ill12](../_media/vigo-idp/app-roles.png)
+![ill12](../../_media/vigo-idp/app-roles.png)
 
 
 ### Koble gruppe i Azure med rolle
 
 - Gå tilbake til Azure AD og klikk på “Enterprise applications”:
 
-![ill13](../_media/vigo-idp/vigoidp13.png)
+![ill13](../../_media/vigo-idp/vigoidp13.png)
 
 - Hvis du ikke ser “VIGO-IDP”: Søk den opp i søkefeltet. Klikk på VIGO-IDP:
 
-![ill14](../_media/vigo-idp/vigoidp14.png)
+![ill14](../../_media/vigo-idp/vigoidp14.png)
 
 - Klikk på “Users and groups”
 
-![ill15](../_media/vigo-idp/vigoidp15.png)
+![ill15](../../_media/vigo-idp/vigoidp15.png)
 
 - Klikk på “Add user/group”:
 
-![ill16](../_media/vigo-idp/vigoidp16.png)
+![ill16](../../_media/vigo-idp/vigoidp16.png)
 
 - Klikk på “None selected” under “Users and groups”:
 
-![ill17](../_media/vigo-idp/vigoidp17.png)
+![ill17](../../_media/vigo-idp/vigoidp17.png)
 
 - Søk opp gruppen:
 
-![ill18](../_media/vigo-idp/vigoidp18.png)
+![ill18](../../_media/vigo-idp/vigoidp18.png)
 
 - Velg gruppen som skal ha tilgang (som skal ha rollen) og velg [Select]:
 
-![ill19](../_media/vigo-idp/vigoidp19.png)
+![ill19](../../_media/vigo-idp/vigoidp19.png)
 
 - Klikk på “None selected” under “Select a role”:
 
-![ill20](../_media/vigo-idp/vigoidp20.png)
+![ill20](../../_media/vigo-idp/vigoidp20.png)
 
 - Har du mange roller så søk opp rollen du opprettet tidligere. Klikk på rollen og velg [Select]:
 
-![ill21](../_media/vigo-idp/vigoidp21.png)
+![ill21](../../_media/vigo-idp/vigoidp21.png)
 
 - Klikk på [Assign]:
 
 I dette tilfellet vil medlemmer av gruppen “TILGANG-VIGO-SAMTYKKE” få rollen “vigo-samtykke-enduser”
 
-![ill22](../_media/vigo-idp/vigoidp22.png)
+![ill22](../../_media/vigo-idp/vigoidp22.png)
 
 I bildet under “Users and groups” vil det vises de som har tilgang til appen og de tilknyttede rollene:
 
-![ill23](../_media/vigo-idp/vigoidp23.png)
+![ill23](../../_media/vigo-idp/vigoidp23.png)
 
 
 ### Legge til claims for SAML autentisering
 
 - I ventre menyen: klikk på “Single sign-on”. Klikk så på “Edit” på punkt 2 under “User Attributes & claims”:
 
-![ill24](../_media/vigo-idp/vigoidp24.png)
+![ill24](../../_media/vigo-idp/vigoidp24.png)
 
 - Klikk på “ + Add new claim”:
 
-![ill25](../_media/vigo-idp/vigoidp25.png)
+![ill25](../../_media/vigo-idp/vigoidp25.png)
 
 Fyll inn:
 
@@ -170,7 +170,7 @@ Fyll inn:
 - Source attribute: Det attributtet i azure ad som innholder studentnumber
   - Verdien hentes fra /utdanning/elev/elev/systemid i Fint og synces via VigoBAS → onprem Ad → Azure AD
 
-![ill26](../_media/vigo-idp/vigoidp26.png)
+![ill26](../../_media/vigo-idp/vigoidp26.png)
 
 Klikk på “ + Add new claim” og fyll inn:
 - Name: employeeId
@@ -179,7 +179,7 @@ Klikk på “ + Add new claim” og fyll inn:
 - Source attribute: Det attributtet i azure ad som inneholder employeeId 
   - Verdien hentes fra /administrasjon/personal/personalressurs/ansattnummer/ i Fint og synces via VigoBAS → onprem Ad → Azure AD
 
-![ill27](../_media/vigo-idp/vigoidp27.png)
+![ill27](../../_media/vigo-idp/vigoidp27.png)
 
 Klikk på “ + Add new claim” og fyll inn:
 - Name: roles
@@ -187,7 +187,7 @@ Klikk på “ + Add new claim” og fyll inn:
 - Source: Attribute
 - Source attribute: user.assignroles
 
-![ill28](../_media/vigo-idp/vigoidp28.png)
+![ill28](../../_media/vigo-idp/vigoidp28.png)
 
 Klikk på “ + Add new claim” og fyll inn:
 - Name: organizationnumber
@@ -195,7 +195,7 @@ Klikk på “ + Add new claim” og fyll inn:
 - Source: Attribute
 - Source attribute: “organisasjonsnummer til fylkeskommunen”
 
-![ill29](../_media/vigo-idp/vigoidp29.png)
+![ill29](../../_media/vigo-idp/vigoidp29.png)
 
 Klikk på “ + Add new claim” og fyll inn:
 - Name: organizationid
@@ -203,17 +203,17 @@ Klikk på “ + Add new claim” og fyll inn:
 - Source: Attribute
 - Source attribute: “dns navn til fylkeskommunen”
 
-![ill30](../_media/vigo-idp/vigoidp30.png)
+![ill30](../../_media/vigo-idp/vigoidp30.png)
 
 I oversikten over User attributes and claims skal det se slik ut:
 
-![ill31](../_media/vigo-idp/vigoidp31.png)
+![ill31](../../_media/vigo-idp/vigoidp31.png)
 
 - Påse at claim under “Required claim” (Name ID) har disse egenskapene:
 
-![ill32](../_media/vigo-idp/vigoidp32.png)
+![ill32](../../_media/vigo-idp/vigoidp32.png)
 
-![ill33](../_media/vigo-idp/vigoidp33.png)
+![ill33](../../_media/vigo-idp/vigoidp33.png)
 
 
 ### Last ned og send sertifikat og metadata til FINT
@@ -222,7 +222,7 @@ I punkt “3 SAML Signing Certificate” : last ned følgende:
 - “Certificate (Base64)”
 - “Federation Metadata XML”
 
-![ill34](../_media/vigo-idp/vigoidp34.png)
+![ill34](../../_media/vigo-idp/vigoidp34.png)
 
 Disse sendes til kontaktpersonen i fintlabs.
 
@@ -234,7 +234,7 @@ Dette kan gjøres etter at Fint har mottat metadata og sertifikat samt konfigure
 - Gå til: https://idp.felleskomponent.no/nidp/
 - I vaffelmenyen, klikk på din fylkeskommune.
 
-![ill35](../_media/vigo-idp/vigoidp35.png)
+![ill35](../../_media/vigo-idp/vigoidp35.png)
 
 For å se selve SAML tokenet så kan man benytte Firefox med SAML-tracer tilleget. 
 
@@ -274,15 +274,15 @@ Gå til url'en som er oppgitt for den tjenesten du skal inn på. Dette kan feks 
 
 Hvis du ikke allrede er innlogget i Office365 til fylket vil du bli videresendt til en autentiseringsvelger. Se under:
 
-![](../_media/vigo-idp/authSelector.png)
+![](../../_media/vigo-idp/authSelector.png)
 
 Klikk på pilen i [Velg tilhøringhet]-boksen og velg din fylkeskommune fra listen som dukker opp. Se under:
 
-![](../_media/vigo-idp/authSelectorList.png)
+![](../../_media/vigo-idp/authSelectorList.png)
 
 Når du har valgt fylkeskommune vil [FORTSETT]-knappen bli grønn. Klikk på denne. Da sendes du til din vanlige pålogging for Office365 til din fylkeskommune. Se under:
 
-![](../_media/vigo-idp/authSelectorSelected.png)
+![](../../_media/vigo-idp/authSelectorSelected.png)
 
 Logg deg inn på vanlig måte i Office365. Du vil nå komme inn i tjenesten hvis din fylkeskommune har gitt deg tilgang til det.
 
@@ -307,7 +307,7 @@ Attributtene som overføres i tokenet ligger da mellom
 
 Se under:
 
-![](../_media/vigo-idp/samlTracer.png)
+![](../../_media/vigo-idp/samlTracer.png)
 
 
 

--- a/frontend/technical/federation/index.md
+++ b/frontend/technical/federation/index.md
@@ -1,0 +1,8 @@
+# Federering
+
+
+| Dokument                                                           | Beskrivelse                                                |
+| :----------------------------------------------------------------- | :--------------------------------------------------------- |
+| [Keycloak](/technical/federation/federation_keycloak.md)           | Veiledning for oppsett av ekstern federering med Keycloak. |
+| [VIGO-IDP (utfases)](/technical/federation/federation_vigo_idp.md) | Veiledning for oppsett av ekstern federering med VIGO-IDP. |
+ 

--- a/frontend/technical/index.md
+++ b/frontend/technical/index.md
@@ -1,11 +1,11 @@
 # Teknisk dokumentasjon
 
 
-| Dokument                                 | Beskrivelse                                                |
-|:-----------------------------------------|:-----------------------------------------------------------|
-| [OAuth2](technical/oauth2.md)            | Beskriver autentiseringsprosessen for tilgang til FINT.    |
-| [JSON](technical/json.md)                | Informasjon om JSON datatypen og verktøy for validering.   |
-| [Testklient](technical/testclient.md)    | Webbasert klient for visning og interaksjon med FINT-data. |
-| [FINT curl](technical/fintcurl.md)       | Kommandolinjeverktøy for å hente data fra FINT.            |
-| [Federering](technical/federation.md)    | Veiledning for oppsett av ekstern federering.              |
-| [FINT internt](technical/fint-inside.md) | Oversikt over interne strukturen i FINT.                   |
+| Dokument                                    | Beskrivelse                                                |
+| :------------------------------------------ | :--------------------------------------------------------- |
+| [OAuth2](technical/oauth2.md)               | Beskriver autentiseringsprosessen for tilgang til FINT.    |
+| [JSON](technical/json.md)                   | Informasjon om JSON datatypen og verktøy for validering.   |
+| [Testklient](technical/testclient.md)       | Webbasert klient for visning og interaksjon med FINT-data. |
+| [FINT curl](technical/fintcurl.md)          | Kommandolinjeverktøy for å hente data fra FINT.            |
+| [Federering](technical/federation/index.md) | Veiledning for oppsett av ekstern federering.              |
+| [FINT internt](technical/fint-inside.md)    | Oversikt over interne strukturen i FINT.                   |


### PR DESCRIPTION
## Summary

- Reorganizes federation documentation into a dedicated section with separate guides for Keycloak and the deprecated VIGO-IDP.
- Adds a Keycloak guide sourced from the external `flais-keycloak` documentation.
- Updates navigation and technical documentation links to the new federation index.
- Preserves the existing VIGO-IDP guide and fixes its image paths after relocation.
- Repairs malformed remote include URLs for Markdown links and images.

This has dependency on: https://github.com/FINTLabs/flais-keycloak/pull/445

If you wanna test the website, you can change the embed url from `main` to `fla-1868`, or wait until the dependent PR is merged.